### PR TITLE
Implement multiple activities and layouts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.AppConejitos">
         <activity
-            android:name=".MainActivity"
+            android:name=".StartActivity"
             android:exported="true"
             android:screenOrientation="landscape">
             <intent-filter>
@@ -20,6 +20,18 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".RulesActivity"
+            android:exported="false"
+            android:screenOrientation="landscape" />
+        <activity
+            android:name=".ResultActivity"
+            android:exported="false"
+            android:screenOrientation="landscape" />
+        <activity
+            android:name=".MainActivity"
+            android:exported="false"
+            android:screenOrientation="landscape" />
 
     </application>
 

--- a/app/src/main/java/com/example/appconejitos/MainActivity.java
+++ b/app/src/main/java/com/example/appconejitos/MainActivity.java
@@ -1,6 +1,8 @@
 package com.example.appconejitos;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.widget.Button;
 import android.widget.ImageView;
 
 import androidx.activity.EdgeToEdge;
@@ -26,13 +28,23 @@ public class MainActivity extends AppCompatActivity {
 
         ranas= new ImageView[7];
         for (int i=0; i<ranas.length; i++){
-         ranas[i]=findViewById(ids[i]);
+            ranas[i]=findViewById(ids[i]);
+            int index = i;
+            ranas[i].setOnClickListener(v -> {
+                moverRanas(index);
+                for (ImageView iv : ranas) {
+                    asignarimagenes(iv);
+                }
+            });
         }
 
+        inicializar();
+        for (ImageView iv : ranas) {
+            asignarimagenes(iv);
+        }
 
-
-
-
+        Button fin = findViewById(R.id.btnFin);
+        fin.setOnClickListener(v -> startActivity(new Intent(this, ResultActivity.class)));
 
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());

--- a/app/src/main/java/com/example/appconejitos/ResultActivity.java
+++ b/app/src/main/java/com/example/appconejitos/ResultActivity.java
@@ -1,0 +1,17 @@
+package com.example.appconejitos;
+
+import android.os.Bundle;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class ResultActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_result);
+
+        Button inicio = findViewById(R.id.btnInicio);
+        inicio.setOnClickListener(v -> finish());
+    }
+}

--- a/app/src/main/java/com/example/appconejitos/RulesActivity.java
+++ b/app/src/main/java/com/example/appconejitos/RulesActivity.java
@@ -1,0 +1,17 @@
+package com.example.appconejitos;
+
+import android.os.Bundle;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class RulesActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_rules);
+
+        Button volver = findViewById(R.id.btnVolver);
+        volver.setOnClickListener(v -> finish());
+    }
+}

--- a/app/src/main/java/com/example/appconejitos/StartActivity.java
+++ b/app/src/main/java/com/example/appconejitos/StartActivity.java
@@ -1,0 +1,23 @@
+package com.example.appconejitos;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.widget.Button;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class StartActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_start);
+
+        Button jugar = findViewById(R.id.btnJugar);
+        Button reglas = findViewById(R.id.btnReglas);
+        Button resultados = findViewById(R.id.btnResultados);
+
+        jugar.setOnClickListener(v -> startActivity(new Intent(this, MainActivity.class)));
+        reglas.setOnClickListener(v -> startActivity(new Intent(this, RulesActivity.class)));
+        resultados.setOnClickListener(v -> startActivity(new Intent(this, ResultActivity.class)));
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -185,4 +185,16 @@
 
     </LinearLayout>
 
+    <Button
+        android:id="@+id/btnFin"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/finalizar"
+        app:layout_constraintTop_toBottomOf="@id/linearLayout"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_result.xml
+++ b/app/src/main/res/layout/activity_result.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/txtResultado"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/resultados"
+        android:layout_gravity="center"
+        android:textSize="18sp" />
+
+    <Button
+        android:id="@+id/btnInicio"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/volver_inicio"
+        android:layout_gravity="bottom|center_horizontal" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/activity_rules.xml
+++ b/app/src/main/res/layout/activity_rules.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/txtRules"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:text="@string/reglas_text"
+        android:gravity="center"
+        android:textSize="18sp" />
+
+    <Button
+        android:id="@+id/btnVolver"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/volver"
+        android:layout_gravity="center_horizontal" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_start.xml
+++ b/app/src/main/res/layout/activity_start.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/fondo">
+
+    <Button
+        android:id="@+id/btnJugar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/jugar"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="32dp" />
+
+    <Button
+        android:id="@+id/btnReglas"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/reglas"
+        android:layout_below="@id/btnJugar"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/btnResultados"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/resultados"
+        android:layout_below="@id/btnReglas"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="16dp" />
+
+</RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">AppConejitos</string>
+    <string name="jugar">Jugar</string>
+    <string name="reglas">Reglas</string>
+    <string name="resultados">Resultados</string>
+    <string name="volver">Volver</string>
+    <string name="volver_inicio">Volver al inicio</string>
+    <string name="reglas_text">Mueve los conejitos al lado contrario saltando uno o dos espacios.</string>
+    <string name="finalizar">Finalizar</string>
 </resources>


### PR DESCRIPTION
## Summary
- add start, rules and result screens
- drive navigation between screens and game
- include layout backgrounds and array-based rabbit logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68bf81cdf0108325bd63d4710f80f0c0